### PR TITLE
Fixed issue when delimiter is the first character

### DIFF
--- a/EnumParser/EnumParser.Test/EnumTest.cs
+++ b/EnumParser/EnumParser.Test/EnumTest.cs
@@ -29,6 +29,14 @@ namespace EnumParser.Test
 
             enumValue.Should().HaveFlag(Notes.Assigned).And.HaveFlag(Notes.Exercised);
         }
+
+        [Test]
+        public void TestLeadingDelimiter()
+        {
+            var enumValue = EnumParser.Parse(typeof(OpenClose), ";O;C");
+
+            enumValue.Should().HaveFlag(OpenClose.C).And.HaveFlag(OpenClose.O);
+        }
     }
 
     [EnumName]

--- a/EnumParser/EnumParser/EnumParser.cs
+++ b/EnumParser/EnumParser/EnumParser.cs
@@ -29,7 +29,7 @@ namespace EnumParser
 
         public static object Parse(Type type, string name)
         {
-            var splits = name.Split(';');
+            var splits = validateName(name).Split(';');
 
             var retVal = splits.Select(x =>
             {
@@ -44,6 +44,15 @@ namespace EnumParser
             }).Aggregate((x, y) => EnumOr(x, y));
 
             return retVal;
+        }
+
+        private static string validateName(string name)
+        {
+            if (name.IndexOf(";") == 0)
+            {
+                return name.Substring(1);
+            };
+            return name;
         }
 
         public static object EnumOr(object enum1, object enum2)


### PR DESCRIPTION
Enum values in IB Flex Queries may start with a delimiter character, e.g. notes=";CP".  In such cases name.Split(";") in Parse() causes an exception.  I added validateName() as a simple check of the first character.